### PR TITLE
fix: add headers limit when reorg

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -9,7 +9,11 @@ use std::{
     thread, time,
 };
 
-use ckb_bitcoin_spv_verifier::types::{core::SpvClient, packed, prelude::Pack as VPack};
+use ckb_bitcoin_spv_verifier::types::{
+    core::{BitcoinChainType, SpvClient},
+    packed,
+    prelude::Pack as VPack,
+};
 use ckb_jsonrpc_types::{Status, TransactionView};
 use ckb_sdk::{
     core::TransactionBuilder,
@@ -194,11 +198,13 @@ impl Args {
 
                     let spv_tip_height = input.curr.client.headers_mmr_root.max_height;
 
-                    let (spv_client, spv_update) = storage.generate_spv_client_and_spv_update(
-                        spv_tip_height,
-                        self.spv_headers_update_limit,
-                        input.info.get_flags()?,
-                    )?;
+                    let flags = input.info.get_flags()?;
+                    let limit = match flags.into() {
+                        BitcoinChainType::Testnet => self.spv_headers_update_limit,
+                        _ => NonZeroU32::MAX,
+                    };
+                    let (spv_client, spv_update) =
+                        storage.generate_spv_client_and_spv_update(spv_tip_height, limit, flags)?;
 
                     let tx_hash =
                         self.reorg_spv_cells(&spv_service, input, spv_client, spv_update)?;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -196,7 +196,7 @@ impl Args {
 
                     let (spv_client, spv_update) = storage.generate_spv_client_and_spv_update(
                         spv_tip_height,
-                        NonZeroU32::MAX,
+                        self.spv_headers_update_limit,
                         input.info.get_flags()?,
                     )?;
 


### PR DESCRIPTION
When a block storm occurs on testnet 3, a reorg might require rolling back a large number of blocks. If no limit is applied, the witness size could even exceed the 32k limit, causing the CKB transaction to fail.

This PR reuses the same limiting parameters as the update.


```bash
[2024-10-09T11:52:19Z DEBUG reqwest::connect] starting new connection: https://testnet.ckb.dev/
Error: ckb rpc error: jsonrpc error: `Server error: TransactionFailedToVerify: Script(TransactionScriptError { source: Inputs[0].Lock, cause: ValidationFailure: see error code -22 on page https://nervosnetwork.github.io/ckb-script-error-codes/by-type-hash/9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8.html#-22 })`

Caused by:
    0: jsonrpc error: `Server error: TransactionFailedToVerify: Script(TransactionScriptError { source: Inputs[0].Lock, cause: ValidationFailure: see error code -22 on page https://nervosnetwork.github.io/ckb-script-error-codes/by-type-hash/9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8.html#-22 })`
    1: Server error: TransactionFailedToVerify: Script(TransactionScriptError { source: Inputs[0].Lock, cause: ValidationFailure: see error code -22 on page https://nervosnetwork.github.io/ckb-script-error-codes/by-type-hash/9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8.html#-22 })
```

```
-22
Witness too long. The system script has a fixed upper bound on the accepted witness size(32K right now). If your witness is too big(for example, an attacker includes too much witness data), this would be returned.
```